### PR TITLE
WLC-49 Enabled the RTC module

### DIFF
--- a/Core/Src/config_mgr.c
+++ b/Core/Src/config_mgr.c
@@ -92,7 +92,7 @@ static void on_rtc_alarm() {
 
 void init_config_mgr() {
     i2c_slave_init(I2C_SLAVE_ADDRESS, on_i2c_event);
-    // init_rtc(on_rtc_alarm);
-    // set_rtc_time(1240);
+    init_rtc(on_rtc_alarm);
+    set_rtc_time(0);
     // set_rtc_alarm_time(1245);
 }

--- a/Core/Src/led_indicator.c
+++ b/Core/Src/led_indicator.c
@@ -47,7 +47,6 @@ static void on_timer_2_tick(bool done) {
             if(dry_pump_hold_time == 0) {
                 set_pump_status(PUMP_OFF);
                 dry_pump_hold_time = DRY_RUN_HOLD_TIME;
-                uart1_send_string("Pump status: OFF\r\n");
             }
         }
     }

--- a/Core/Src/pump_controller.c
+++ b/Core/Src/pump_controller.c
@@ -68,7 +68,6 @@ static void on_pumping_tick(bool done) {
         set_pump_status(PUMP_DRY_RUN);
         seconds = 0;
         dry_run_sec = 0;
-        uart1_send_string("Pump status: Dry Run\r\n");
     }
 
     if(done) {


### PR DESCRIPTION
There was an issue in the hardware. When the PC14 and PC15 connected to the bread board, it leads to add a stray capacitance for the RTC crystal oscillator. This leads to inacurate RTC timing