### PR TITLE
WLC-50 Cleared the interrupt flag and pulled up the I2C bus

### DIFF
--- a/Core/Src/i2c.c
+++ b/Core/Src/i2c.c
@@ -73,6 +73,18 @@ void I2C1_EV_IRQHandler() {
             I2C1->SR1 &= ~I2C_SR1_AF;
             i2c_mode = I2C_MODE_UNKNOWN;
         }
+    } else {
+        if(I2C1->SR1 & I2C_SR1_BERR) {
+            // Clear if any bus error
+            I2C1->SR1 &= ~I2C_SR1_BERR;
+            uart1_send_string("Bus Error cleared\r\n");
+        } else if(I2C1->SR1 & I2C_SR1_STOPF) {
+            // Clear the STOPF flag by reading SR1 and
+            // writing into CR1.
+            (void)I2C1->SR1;
+            I2C1->CR1 |= I2C_CR1_PE;
+            uart1_send_string("Stop bit error cleared\r\n");
+        }
     }
 }
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -109,6 +109,7 @@ void delay(uint32_t ms) {
 }
 
 int main(void) {
+    __disable_irq();
 #ifdef DEBUG_ENABLED
     RCC->APB2ENR |= RCC_APB2ENR_IOPCEN;
 
@@ -118,7 +119,6 @@ int main(void) {
     TURN_OFF_LED();
 #endif
 
-    __disable_irq();
     config_sys_clock();
     uart1_setup(UART_TX_ENABLE);
     init_config_mgr();


### PR DESCRIPTION
The issue happens because the configuration manager initializes the I2C but the I2C bus is not pulled up to logical high. This leads to call the ISR due to the bus error detection. At the moment the __enable_irq() function is called, the interrupt started to trigger. since the flag is not clearing for bus error and STOPF the ISR getting called continuously

